### PR TITLE
Add Petal Press — collect/dry/craft game with GitHub Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy Petal Press to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "game/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+# Allow GITHUB_TOKEN to deploy to Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one concurrent deployment; don't cancel in-progress production deploys
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload game/ as Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: game
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/game/README.md
+++ b/game/README.md
@@ -1,0 +1,41 @@
+# 🌸 Petal Press
+
+A cozy little browser game: **collect** petals from flowers, **dry** them on a
+board, and **press** them into pretty crafts.
+
+No build step, no dependencies — just static HTML/CSS/JS, so it deploys straight
+to GitHub Pages.
+
+## Play locally
+
+Open `index.html` in a browser, or serve the folder:
+
+```bash
+cd game
+python3 -m http.server 8000
+# then visit http://localhost:8000
+```
+
+## How to play
+
+1. **Garden** — tap a blooming flower to gather petals into the *Fresh* tray.
+   Flowers re-bloom after a short while.
+2. **Drying Board** — tap a fresh petal to lay it on the board. Wait for the ring
+   to fill, then it becomes a *dried* petal.
+3. **Craft** — tap a dried petal to press it into a matching coloured spot on the
+   pattern. Fill the whole picture to complete the craft and start a new one.
+
+## Deployment
+
+The included GitHub Actions workflow (`.github/workflows/pages.yml`) publishes
+the `game/` folder to GitHub Pages on every push to `main` (or via manual
+dispatch). Enable it once under **Settings → Pages → Build and deployment →
+Source: GitHub Actions**.
+
+## Files
+
+| File         | Purpose                                  |
+| ------------ | ---------------------------------------- |
+| `index.html` | Markup + layout                          |
+| `style.css`  | Cottagecore styling, animations          |
+| `game.js`    | Game state, garden/rack/craft logic      |

--- a/game/game.js
+++ b/game/game.js
@@ -1,0 +1,418 @@
+/* Petal Press — a cozy collect / dry / craft game.
+ * No dependencies, no build step. Pure DOM + CSS so it deploys
+ * straight to GitHub Pages as static files. */
+
+(() => {
+  "use strict";
+
+  // ---- Palette --------------------------------------------------------
+  const COLORS = {
+    pink: { var: "var(--pink)", emoji: "🌸", name: "pink" },
+    yellow: { var: "var(--yellow)", emoji: "🌻", name: "yellow" },
+    purple: { var: "var(--purple)", emoji: "🪻", name: "purple" },
+    red: { var: "var(--red)", emoji: "🌹", name: "red" },
+    blue: { var: "var(--blue)", emoji: "🪻", name: "blue" },
+  };
+  const FLOWER_EMOJI = {
+    pink: "🌸",
+    yellow: "🌻",
+    purple: "🌷",
+    red: "🌹",
+    blue: "💐",
+  };
+
+  const DRY_MS = 5000; // time for a petal to dry
+  const REGROW_MS = 6000; // time for a flower to re-bloom
+  const RACK_SIZE = 8; // slots on the drying board
+  const GARDEN_SIZE = 9; // flowers in the garden
+
+  // ---- State ----------------------------------------------------------
+  let uid = 0;
+  const state = {
+    flowers: [], // {color, bloom:true|false, regrowAt}
+    fresh: [], // {id, color}
+    rack: new Array(RACK_SIZE).fill(null), // {id, color, dryAt} | null
+    dry: [], // {id, color}
+    craft: null, // {name, cols, rows, cells:[{color|null, filled}]}
+    craftIndex: -1,
+    stats: { crafts: 0, collected: 0, score: 0 },
+  };
+
+  // ---- Craft patterns -------------------------------------------------
+  // Char map: . = empty, letters map to colours below.
+  const LEGEND = { p: "pink", y: "yellow", u: "purple", r: "red", b: "blue" };
+  const CRAFTS = [
+    {
+      name: "Heart",
+      art: [
+        ".pp.pp.",
+        "ppppppp",
+        "ppppppp",
+        ".ppppp.",
+        "..ppp..",
+        "...p...",
+      ],
+    },
+    {
+      name: "Sunflower",
+      art: [
+        "..y.y..",
+        ".yyyyy.",
+        "yyrryyy",
+        "yyrryyy",
+        ".yyyyy.",
+        "..y.y..",
+      ],
+    },
+    {
+      name: "Butterfly",
+      art: [
+        "bb.b.bb",
+        "bub.bub",
+        "bbb.bbb",
+        ".b.u.b.",
+        "bbb.bbb",
+        "bu.b.ub",
+      ],
+    },
+    {
+      name: "Tulip Bunch",
+      art: [
+        "r.p.u.r",
+        "rrppuur",
+        "rrppuur",
+        ".rppuu.",
+        "..yyy..",
+        "...y...",
+      ],
+    },
+    {
+      name: "Rainbow",
+      art: [
+        "rrrrrrr",
+        "yyyyyyy",
+        "ppppppp",
+        "uuuuuuu",
+        "bbbbbbb",
+      ],
+    },
+  ];
+
+  // ---- DOM refs -------------------------------------------------------
+  const $ = (id) => document.getElementById(id);
+  const gardenEl = $("garden");
+  const freshEl = $("fresh");
+  const rackEl = $("rack");
+  const dryEl = $("dry");
+  const craftEl = $("craft");
+  const craftNameEl = $("craft-name");
+  const toastEl = $("toast");
+
+  // ---- Helpers --------------------------------------------------------
+  function makePetal(color, { dried = false } = {}) {
+    const el = document.createElement("button");
+    el.className = "petal" + (dried ? " dried" : "");
+    el.style.setProperty("--c", COLORS[color].var);
+    el.style.animation = "pop-in .25s ease";
+    el.setAttribute("aria-label", `${color} ${dried ? "dried " : ""}petal`);
+    return el;
+  }
+
+  let toastTimer;
+  function toast(msg) {
+    toastEl.textContent = msg;
+    toastEl.classList.add("show");
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => toastEl.classList.remove("show"), 1800);
+  }
+
+  function updateStats() {
+    $("stat-crafts").textContent = state.stats.crafts;
+    $("stat-collected").textContent = state.stats.collected;
+    $("stat-score").textContent = state.stats.score;
+  }
+
+  // ---- Garden ---------------------------------------------------------
+  function initGarden() {
+    const palette = Object.keys(COLORS);
+    state.flowers = Array.from({ length: GARDEN_SIZE }, () => ({
+      color: palette[Math.floor(Math.random() * palette.length)],
+      bloom: true,
+      regrowAt: 0,
+    }));
+    renderGarden();
+  }
+
+  function renderGarden() {
+    gardenEl.innerHTML = "";
+    state.flowers.forEach((f, i) => {
+      const btn = document.createElement("button");
+      btn.className = "flower" + (f.bloom ? "" : " wilted");
+      btn.disabled = !f.bloom;
+      btn.innerHTML = `<span>${FLOWER_EMOJI[f.color]}</span>`;
+      if (!f.bloom) {
+        const bar = document.createElement("div");
+        bar.className = "regrow-bar";
+        bar.innerHTML = "<i></i>";
+        btn.appendChild(bar);
+      }
+      btn.addEventListener("click", () => pickFlower(i));
+      gardenEl.appendChild(btn);
+    });
+  }
+
+  function pickFlower(i) {
+    const f = state.flowers[i];
+    if (!f.bloom) return;
+    const count = 2 + Math.floor(Math.random() * 2); // 2–3 petals
+    for (let k = 0; k < count; k++) {
+      state.fresh.push({ id: ++uid, color: f.color });
+    }
+    state.stats.collected += count;
+    f.bloom = false;
+    f.regrowAt = Date.now() + REGROW_MS;
+    // re-roll colour so the garden stays varied
+    const palette = Object.keys(COLORS);
+    f.color = palette[Math.floor(Math.random() * palette.length)];
+    renderGarden();
+    renderFresh();
+    updateStats();
+    toast(`+${count} ${COLORS[state.fresh[state.fresh.length - 1].color].name} petals`);
+  }
+
+  // ---- Fresh tray -----------------------------------------------------
+  function renderFresh() {
+    freshEl.innerHTML = "";
+    state.fresh.forEach((p) => {
+      const el = makePetal(p.color);
+      el.title = "Tap to dry on the board";
+      el.addEventListener("click", () => moveToRack(p.id));
+      freshEl.appendChild(el);
+    });
+  }
+
+  function moveToRack(id) {
+    const slot = state.rack.indexOf(null);
+    if (slot === -1) {
+      toast("The drying board is full!");
+      return;
+    }
+    const idx = state.fresh.findIndex((p) => p.id === id);
+    if (idx === -1) return;
+    const [p] = state.fresh.splice(idx, 1);
+    state.rack[slot] = { id: p.id, color: p.color, dryAt: Date.now() + DRY_MS };
+    renderFresh();
+    renderRack();
+  }
+
+  // ---- Drying rack ----------------------------------------------------
+  function renderRack() {
+    rackEl.innerHTML = "";
+    for (let i = 0; i < RACK_SIZE; i++) {
+      const slot = document.createElement("div");
+      slot.className = "slot";
+      const item = state.rack[i];
+      if (item) {
+        const wrap = document.createElement("div");
+        wrap.className = "drying";
+        const ring = document.createElement("div");
+        ring.className = "ring";
+        const petal = makePetal(item.color);
+        petal.style.animation = "none";
+        wrap.appendChild(ring);
+        wrap.appendChild(petal);
+        wrap.dataset.idx = i;
+        petal.addEventListener("click", () => collectDried(i));
+        slot.appendChild(wrap);
+      }
+      rackEl.appendChild(slot);
+    }
+    tickRack(); // paint initial progress
+  }
+
+  function collectDried(i) {
+    const item = state.rack[i];
+    if (!item || Date.now() < item.dryAt) return;
+    state.dry.push({ id: item.id, color: item.color });
+    state.rack[i] = null;
+    renderRack();
+    renderDry();
+  }
+
+  // Update drying rings + flower regrowth on an animation loop.
+  function tickRack() {
+    const now = Date.now();
+    rackEl.querySelectorAll(".drying").forEach((wrap) => {
+      const i = +wrap.dataset.idx;
+      const item = state.rack[i];
+      if (!item) return;
+      const remaining = item.dryAt - now;
+      const p = Math.max(0, Math.min(1, 1 - remaining / DRY_MS));
+      wrap.querySelector(".ring").style.setProperty("--p", (p * 100).toFixed(1) + "%");
+      wrap.classList.toggle("done", remaining <= 0);
+    });
+  }
+
+  function loop() {
+    tickRack();
+    const now = Date.now();
+    let gardenDirty = false;
+    state.flowers.forEach((f) => {
+      if (!f.bloom) {
+        if (now >= f.regrowAt) {
+          f.bloom = true;
+          gardenDirty = true;
+        }
+      }
+    });
+    if (gardenDirty) renderGarden();
+    // animate regrow bars
+    state.flowers.forEach((f, i) => {
+      if (!f.bloom) {
+        const btn = gardenEl.children[i];
+        const bar = btn && btn.querySelector(".regrow-bar i");
+        if (bar) {
+          const prog = 1 - (f.regrowAt - now) / REGROW_MS;
+          bar.style.width = Math.max(0, Math.min(1, prog)) * 100 + "%";
+        }
+      }
+    });
+    requestAnimationFrame(loop);
+  }
+
+  // ---- Dried tray -----------------------------------------------------
+  function renderDry() {
+    dryEl.innerHTML = "";
+    state.dry.forEach((p) => {
+      const el = makePetal(p.color, { dried: true });
+      el.title = "Tap to press into the craft";
+      el.addEventListener("click", () => pressIntoCraft(p.id));
+      dryEl.appendChild(el);
+    });
+    highlightWantedColors();
+  }
+
+  // ---- Craft ----------------------------------------------------------
+  function loadCraft(index) {
+    const def = CRAFTS[index % CRAFTS.length];
+    const rows = def.art.length;
+    const cols = Math.max(...def.art.map((r) => r.length));
+    const cells = [];
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const ch = def.art[r][c] || ".";
+        const color = LEGEND[ch] || null;
+        cells.push({ color, filled: false });
+      }
+    }
+    state.craft = { name: def.name, cols, rows, cells };
+    state.craftIndex = index;
+    craftNameEl.textContent = def.name;
+    renderCraft();
+  }
+
+  function renderCraft() {
+    const { cols, cells } = state.craft;
+    craftEl.style.gridTemplateColumns = `repeat(${cols}, 30px)`;
+    craftEl.innerHTML = "";
+    cells.forEach((cell) => {
+      const el = document.createElement("div");
+      if (!cell.color) {
+        el.className = "cell empty";
+      } else if (cell.filled) {
+        el.className = "cell filled";
+        el.style.setProperty("--c", COLORS[cell.color].var);
+      } else {
+        el.className = "cell slot-open";
+        el.style.setProperty("--c", COLORS[cell.color].var);
+      }
+      craftEl.appendChild(el);
+    });
+    highlightWantedColors();
+  }
+
+  // Pulse open slots whose colour we currently have a dried petal for.
+  function highlightWantedColors() {
+    if (!state.craft) return;
+    const have = new Set(state.dry.map((p) => p.color));
+    const cellEls = craftEl.children;
+    state.craft.cells.forEach((cell, i) => {
+      const el = cellEls[i];
+      if (el && el.classList.contains("slot-open")) {
+        el.classList.toggle("wanted", have.has(cell.color));
+      }
+    });
+  }
+
+  function pressIntoCraft(id) {
+    const pIdx = state.dry.findIndex((p) => p.id === id);
+    if (pIdx === -1) return;
+    const color = state.dry[pIdx].color;
+    const cellIdx = state.craft.cells.findIndex(
+      (c) => c.color === color && !c.filled
+    );
+    if (cellIdx === -1) {
+      toast(`No ${COLORS[color].name} spot left — try another colour`);
+      return;
+    }
+    state.craft.cells[cellIdx].filled = true;
+    state.dry.splice(pIdx, 1);
+    state.stats.score += 5;
+    renderDry();
+    renderCraft();
+    updateStats();
+
+    if (state.craft.cells.every((c) => !c.color || c.filled)) {
+      finishCraft();
+    }
+  }
+
+  function finishCraft() {
+    state.stats.crafts += 1;
+    state.stats.score += 50;
+    updateStats();
+    celebrate();
+    toast(`🎀 "${state.craft.name}" complete!  +50`);
+    setTimeout(() => loadCraft(state.craftIndex + 1), 1400);
+  }
+
+  // ---- Confetti -------------------------------------------------------
+  function celebrate() {
+    const colors = Object.values(COLORS).map((c) => c.var);
+    for (let i = 0; i < 80; i++) {
+      const c = document.createElement("div");
+      c.className = "confetti";
+      c.style.left = Math.random() * 100 + "vw";
+      c.style.background = colors[i % colors.length];
+      c.style.animationDuration = 1.6 + Math.random() * 1.4 + "s";
+      c.style.animationDelay = Math.random() * 0.4 + "s";
+      c.style.borderRadius = Math.random() > 0.5 ? "50%" : "2px";
+      document.body.appendChild(c);
+      setTimeout(() => c.remove(), 3400);
+    }
+  }
+
+  // ---- Help modal -----------------------------------------------------
+  $("help-btn").addEventListener("click", () => $("help").classList.remove("hidden"));
+  $("help-close").addEventListener("click", () => $("help").classList.add("hidden"));
+  $("help").addEventListener("click", (e) => {
+    if (e.target === $("help")) $("help").classList.add("hidden");
+  });
+
+  // ---- Boot -----------------------------------------------------------
+  function start() {
+    initGarden();
+    renderFresh();
+    renderRack();
+    renderDry();
+    loadCraft(0);
+    updateStats();
+    requestAnimationFrame(loop);
+    if (!localStorage.getItem("petalPressSeen")) {
+      $("help").classList.remove("hidden");
+      localStorage.setItem("petalPressSeen", "1");
+    }
+  }
+
+  start();
+})();

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Petal Press 🌸 — collect, dry & craft</title>
+    <meta
+      name="description"
+      content="A cozy little game: collect petals from flowers, dry them on a board, and press them into pretty crafts."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌸</text></svg>"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <h1>🌸 Petal Press</h1>
+      <div class="stats">
+        <span class="stat" title="Crafts completed">🎀 <b id="stat-crafts">0</b></span>
+        <span class="stat" title="Petals collected">🌼 <b id="stat-collected">0</b></span>
+        <span class="stat" title="Score">⭐ <b id="stat-score">0</b></span>
+      </div>
+      <button id="help-btn" class="ghost-btn" aria-label="How to play">How to play</button>
+    </header>
+
+    <main class="board">
+      <!-- 1. GARDEN -->
+      <section class="panel garden" aria-label="Garden">
+        <h2><span class="num">1</span> Garden</h2>
+        <p class="hint">Tap a flower in bloom to gather its petals.</p>
+        <div id="garden" class="garden-grid"></div>
+      </section>
+
+      <!-- 2. DRYING RACK -->
+      <section class="panel rack-panel" aria-label="Drying board">
+        <h2><span class="num">2</span> Drying Board</h2>
+        <p class="hint">
+          Tap a fresh petal to lay it on the board. It dries on its own.
+        </p>
+        <div class="tray">
+          <div class="tray-label">Fresh petals</div>
+          <div id="fresh" class="fresh-tray"></div>
+        </div>
+        <div id="rack" class="rack"></div>
+      </section>
+
+      <!-- 3. CRAFT -->
+      <section class="panel craft-panel" aria-label="Craft">
+        <h2><span class="num">3</span> Pressed Craft: <span id="craft-name">—</span></h2>
+        <p class="hint">
+          Tap a dried petal to press it into a matching spot. Fill them all!
+        </p>
+        <div class="tray dry-tray-wrap">
+          <div class="tray-label">Dried petals</div>
+          <div id="dry" class="dry-tray"></div>
+        </div>
+        <div id="craft" class="craft-grid"></div>
+      </section>
+    </main>
+
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+    <div id="help" class="modal hidden" role="dialog" aria-modal="true">
+      <div class="modal-card">
+        <h2>How to play 🌷</h2>
+        <ol>
+          <li><b>Collect:</b> tap a blooming flower to gather petals into the <i>Fresh</i> tray. Flowers re-bloom after a little while.</li>
+          <li><b>Dry:</b> tap a fresh petal to place it on the drying board. Wait for the ring to fill — then it's a <i>dried</i> petal.</li>
+          <li><b>Craft:</b> tap a dried petal to press it into a matching coloured spot on the pattern. Complete the picture to finish the craft and start a new one!</li>
+        </ol>
+        <p class="tip">Tip: each craft tells you which colours it needs. Plan your picking!</p>
+        <button id="help-close" class="primary-btn">Got it</button>
+      </div>
+    </div>
+
+    <script src="game.js"></script>
+  </body>
+</html>

--- a/game/style.css
+++ b/game/style.css
@@ -1,0 +1,454 @@
+:root {
+  --pink: #e8628c;
+  --yellow: #f4c430;
+  --purple: #9b7cc9;
+  --red: #e8483a;
+  --blue: #5b8def;
+
+  --bg1: #f7efe4;
+  --bg2: #e9f3dd;
+  --ink: #4a3b33;
+  --wood: #b88a5e;
+  --wood-dark: #9a6f48;
+  --panel: #fffdf8;
+  --shadow: rgba(74, 59, 51, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  color: var(--ink);
+  background: radial-gradient(circle at 20% 10%, var(--bg2), var(--bg1));
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* ---------- Top bar ---------- */
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 14px 22px;
+  background: rgba(255, 253, 248, 0.85);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 2px 12px var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.5px;
+}
+
+.stats {
+  display: flex;
+  gap: 14px;
+  margin-left: auto;
+  font-size: 1.05rem;
+}
+
+.stat {
+  background: #fff;
+  border: 2px solid #f0e6d8;
+  border-radius: 999px;
+  padding: 4px 12px;
+  white-space: nowrap;
+}
+
+.ghost-btn {
+  border: 2px solid var(--wood);
+  color: var(--wood-dark);
+  background: transparent;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ghost-btn:hover {
+  background: var(--wood);
+  color: #fff;
+}
+
+/* ---------- Layout ---------- */
+.board {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  padding: 22px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+@media (max-width: 920px) {
+  .board {
+    grid-template-columns: 1fr;
+  }
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: 0 6px 20px var(--shadow);
+  min-height: 360px;
+}
+
+.panel h2 {
+  margin: 0 0 4px;
+  font-size: 1.15rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.num {
+  background: var(--pink);
+  color: #fff;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: inline-grid;
+  place-items: center;
+  font-size: 0.9rem;
+}
+
+.hint {
+  margin: 0 0 14px;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+/* ---------- Garden ---------- */
+.garden-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.flower {
+  position: relative;
+  aspect-ratio: 1;
+  border: none;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #eaf6e0, #d9eecb);
+  cursor: pointer;
+  font-size: 2.6rem;
+  display: grid;
+  place-items: center;
+  transition: transform 0.12s ease, filter 0.2s ease;
+  overflow: hidden;
+}
+.flower::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 26%;
+  background: linear-gradient(180deg, transparent, #b6d99a);
+}
+.flower:hover:not(:disabled) {
+  transform: translateY(-3px) scale(1.03);
+}
+.flower:active:not(:disabled) {
+  transform: scale(0.95);
+}
+.flower span {
+  position: relative;
+  z-index: 1;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.15));
+}
+.flower.wilted {
+  cursor: default;
+  filter: grayscale(0.6) brightness(1.05);
+}
+.flower.wilted span {
+  opacity: 0.35;
+  transform: scale(0.7);
+}
+.flower .regrow-bar {
+  position: absolute;
+  bottom: 6px;
+  left: 12%;
+  width: 76%;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+  z-index: 2;
+}
+.flower .regrow-bar i {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: #7bb661;
+}
+
+/* ---------- Petals ---------- */
+.petal {
+  width: 30px;
+  height: 30px;
+  border: none;
+  cursor: pointer;
+  background: var(--c, var(--pink));
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+  box-shadow: inset 0 -3px 4px rgba(0, 0, 0, 0.18),
+    inset 0 3px 5px rgba(255, 255, 255, 0.45);
+  transition: transform 0.12s ease;
+  flex: 0 0 auto;
+}
+.petal:hover {
+  transform: scale(1.18) rotate(8deg);
+}
+.petal.dried {
+  filter: saturate(0.55) brightness(0.92);
+  border-radius: 46% 54% 50% 50% / 58% 62% 38% 42%;
+  box-shadow: inset 0 -2px 3px rgba(0, 0, 0, 0.3);
+}
+
+@keyframes pop-in {
+  from {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+/* ---------- Trays ---------- */
+.tray {
+  margin-bottom: 14px;
+}
+.tray-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  opacity: 0.55;
+  margin-bottom: 6px;
+}
+.fresh-tray,
+.dry-tray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 42px;
+  padding: 8px;
+  border-radius: 12px;
+  background: #f6f0e6;
+  border: 2px dashed #e2d5c1;
+}
+.dry-tray {
+  background: #f3ecdf;
+}
+
+/* ---------- Rack ---------- */
+.rack {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  padding: 14px;
+  border-radius: 14px;
+  background: repeating-linear-gradient(
+    180deg,
+    var(--wood),
+    var(--wood) 14px,
+    var(--wood-dark) 14px,
+    var(--wood-dark) 16px
+  );
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+.slot {
+  aspect-ratio: 1;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.drying {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+}
+.drying .petal {
+  width: 22px;
+  height: 22px;
+  cursor: default;
+}
+.drying .ring {
+  position: absolute;
+  inset: -5px;
+  border-radius: 50%;
+  background: conic-gradient(#7bb661 var(--p, 0%), rgba(255, 255, 255, 0.25) 0);
+  -webkit-mask: radial-gradient(farthest-side, transparent 64%, #000 66%);
+  mask: radial-gradient(farthest-side, transparent 64%, #000 66%);
+}
+.drying.done .ring {
+  background: #7bb661;
+  animation: ready-pulse 1.1s ease-in-out infinite;
+}
+.drying.done .petal {
+  cursor: pointer;
+}
+@keyframes ready-pulse {
+  50% {
+    opacity: 0.45;
+  }
+}
+
+/* ---------- Craft ---------- */
+.craft-grid {
+  display: grid;
+  gap: 5px;
+  padding: 14px;
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: inset 0 0 0 3px #f1e7d6, 0 4px 10px var(--shadow);
+  width: fit-content;
+  margin: 0 auto;
+}
+.cell {
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+}
+.cell.empty {
+  background: transparent;
+}
+.cell.slot-open {
+  background: var(--c);
+  opacity: 0.22;
+  outline: 2px dashed var(--c);
+  outline-offset: -2px;
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+}
+.cell.slot-open.wanted {
+  opacity: 0.5;
+  animation: w-pulse 0.9s ease-in-out infinite;
+}
+@keyframes w-pulse {
+  50% {
+    opacity: 0.85;
+  }
+}
+.cell.filled {
+  background: var(--c);
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+  box-shadow: inset 0 -3px 4px rgba(0, 0, 0, 0.2),
+    inset 0 3px 5px rgba(255, 255, 255, 0.45);
+  animation: pop-in 0.25s ease;
+}
+
+#craft-name {
+  color: var(--pink);
+}
+
+/* ---------- Toast ---------- */
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(40px);
+  background: var(--ink);
+  color: #fff;
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-weight: 600;
+  box-shadow: 0 6px 20px var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.35s ease;
+  z-index: 20;
+}
+.toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ---------- Modal ---------- */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(74, 59, 51, 0.5);
+  display: grid;
+  place-items: center;
+  z-index: 30;
+  padding: 20px;
+}
+.modal.hidden {
+  display: none;
+}
+.modal-card {
+  background: var(--panel);
+  border-radius: 18px;
+  padding: 26px;
+  max-width: 460px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+}
+.modal-card h2 {
+  margin-top: 0;
+}
+.modal-card ol {
+  padding-left: 20px;
+  line-height: 1.6;
+}
+.tip {
+  background: #f6f0e6;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 0.9rem;
+}
+.primary-btn {
+  background: var(--pink);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 22px;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+}
+.primary-btn:hover {
+  filter: brightness(1.05);
+}
+
+/* ---------- Confetti ---------- */
+.confetti {
+  position: fixed;
+  top: -10px;
+  width: 10px;
+  height: 14px;
+  z-index: 25;
+  pointer-events: none;
+  animation: fall linear forwards;
+}
+@keyframes fall {
+  to {
+    transform: translateY(105vh) rotate(720deg);
+    opacity: 0.9;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}


### PR DESCRIPTION
## 🌸 Petal Press

A cozy, standalone browser game where you **collect** petals from flowers, **dry** them on a board, and **press** them into pretty crafts. Lives entirely in `game/` and is independent of the webdvd player.

### Gameplay
1. **Garden** — tap blooming flowers to gather petals into the *Fresh* tray. Flowers wilt and re-bloom on a timer.
2. **Drying Board** — tap a fresh petal to lay it on the rack; a progress ring fills as it dries into a *dried* petal.
3. **Craft** — tap a dried petal to press it into a matching-colour slot. Complete the picture (Heart, Sunflower, Butterfly, Tulip Bunch, Rainbow) for confetti + points, then the next craft loads.

Extras: score/petals/crafts counters, a "How to play" modal (auto-shown on first visit), toasts, pulsing slot hints for colours you currently hold, and `prefers-reduced-motion` support.

### Tech
- Pure DOM + CSS + vanilla JS — **no build step, no dependencies**, so it deploys to GitHub Pages as static files.
- New workflow `.github/workflows/pages.yml` publishes the `game/` folder via GitHub Actions on pushes to `main` (or manual dispatch).

### After merge
Enable **Settings → Pages → Build and deployment → Source: GitHub Actions** (one-time) so the workflow can publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKeSXsLWKSEhzJKBvcTsEY)_